### PR TITLE
add the code for trade_type is app

### DIFF
--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -30,10 +30,10 @@ module WxPay
           timestamp: Time.now.to_i.to_s,
           prepayid: r["prepay_id"]
         }
-      r["sign"] = Sign.generate(sign_again_params)
+        r["sign"] = WxPay::Sign.generate(sign_again_params)
 
       end
-      
+
       yield r if block_given?
 
       r

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -17,6 +17,23 @@ module WxPay
 
       r = invoke_remote("#{GATEWAY_URL}/unifiedorder", make_payload(params))
 
+      # when trade_type is app, signing again is needed, the sigin params are below 
+      # appid，partnerid，prepayid，noncestr，timestamp，package。
+      # notice: package is "Sign=WXPay", noncestr is the same as the params[:nonce_str]
+      # prepayid is the r["prepay_id"]
+      if params[:trade_type] == 'APP' && r["return_code"] == "SUCCESS" && r["result_code"] == "SUCCESS"
+        sign_again_params = {
+          appid: params[:appid],
+          noncestr: params[:nonce_str],
+          package: 'Sign=WXPay',
+          partnerid: params[:mch_id],
+          timestamp: Time.now.to_i.to_s,
+          prepayid: r["prepay_id"]
+        }
+      r["sign"] = Sign.generate(sign_again_params)
+
+      end
+      
       yield r if block_given?
 
       r


### PR DESCRIPTION
      when trade_type is app, signing again is needed, the sigin params are below 
      appid，partnerid，prepayid，noncestr，timestamp，package。
      notice: package is "Sign=WXPay", noncestr is the same as the params[:nonce_str]，prepayid is the r["prepay_id"]