### PR TITLE
modify Readme simple example

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ def notify
 
     render :xml => {return_code: "SUCCESS"}.to_xml(root: 'xml', dasherize: false)
   else
-    render :xml => {return_code: "SUCCESS", return_msg: "签名失败"}.to_xml(root: 'xml', dasherize: false)
+    render :xml => {return_code: "FAIL", return_msg: "签名失败"}.to_xml(root: 'xml', dasherize: false)
   end
 end
 ```


### PR DESCRIPTION
Params verify fail maybe better set return_code FAIL, according to wechat suggestion. URI: https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=9_7