### PR TITLE
微信企业付款

### DIFF
--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -38,7 +38,7 @@ module WxPay
       params
     end
 
-    INVOKE_REFUND_REQUIRED_FIELDS = %i(transaction_id out_trade_no out_refund_no total_fee refund_fee)
+    INVOKE_REFUND_REQUIRED_FIELDS = %i(out_refund_no total_fee refund_fee)
     def self.invoke_refund(params)
       params = {
         appid: WxPay.appid,

--- a/lib/wx_pay/sign.rb
+++ b/lib/wx_pay/sign.rb
@@ -6,8 +6,8 @@ module WxPay
       key = params.delete(:key)
 
       query = params.sort.map do |key, value|
-        "#{key}=#{value}"
-      end.join('&')
+        "#{key}=#{value}" if value != "" && !value.nil?
+      end.compact.join('&')
 
       Digest::MD5.hexdigest("#{query}&key=#{key || WxPay.key}").upcase
     end


### PR DESCRIPTION
1. 实现了一个`invoke_remote_with_cert`方法，原来把ssl相关的参数直接写进`WxPay.extra_rest_client_options`感觉有点问题，会覆盖掉用户设置的参数
2. 企业付款`WxPay::Service.invoke_transfer`
3. 改进了一下签名，根据 https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=9_4 ，值为空的参数不参与签名，之前碰到这个坑卡了好久