### PR TITLE
WxPay::Result should return nil for nonexistent key

### DIFF
--- a/lib/wx_pay/result.rb
+++ b/lib/wx_pay/result.rb
@@ -2,14 +2,16 @@ module WxPay
   class Result < ::Hash
     SUCCESS_FLAG = 'SUCCESS'.freeze
 
-    def initialize(result)
-      super
+    def self.[] result
+      hash = super
 
       if result['xml'].class == Hash
         result['xml'].each_pair do |k, v|
-          self[k] = v
+          hash[k] = v
         end
       end
+
+      hash
     end
 
     def success?

--- a/lib/wx_pay/result.rb
+++ b/lib/wx_pay/result.rb
@@ -3,7 +3,7 @@ module WxPay
     SUCCESS_FLAG = 'SUCCESS'.freeze
 
     def self.[] result
-      hash = super
+      hash = self.new
 
       if result['xml'].class == Hash
         result['xml'].each_pair do |k, v|

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -171,7 +171,7 @@ module WxPay
       )
 
       if r
-        WxPay::Result.new Hash.from_xml(r)
+        WxPay::Result[Hash.from_xml(r)]
       else
         nil
       end

--- a/test/wx_pay/result_test.rb
+++ b/test/wx_pay/result_test.rb
@@ -16,7 +16,7 @@ class WxPay::ResultTest < MiniTest::Test
     assert_equal r.success?, true
   end
 
-  def test_success_method_with_true
+  def test_nonexistent_key
     r = WxPay::Result[
       Hash.from_xml(
         <<-XML
@@ -31,6 +31,7 @@ class WxPay::ResultTest < MiniTest::Test
 
     assert_equal r['return_code'].nil?, false
     assert_equal r['prepay_id'].nil?, true
+    assert_equal r.keys, ['return_code', 'code_url', 'result_code']
   end
 
   def test_success_method_with_false

--- a/test/wx_pay/result_test.rb
+++ b/test/wx_pay/result_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class WxPay::ResultTest < MiniTest::Test
   def test_success_method_with_true
-    r = WxPay::Result.new(
+    r = WxPay::Result[
       Hash.from_xml(
         <<-XML
         <xml>
@@ -10,19 +10,38 @@ class WxPay::ResultTest < MiniTest::Test
           <result_code>SUCCESS</result_code>
         </xml>
         XML
-      ))
+      )
+    ]
 
     assert_equal r.success?, true
   end
 
+  def test_success_method_with_true
+    r = WxPay::Result[
+      Hash.from_xml(
+        <<-XML
+        <xml>
+          <return_code>SUCCESS</return_code>
+          <code_url>wx_code_url</code_url>
+          <result_code>SUCCESS</result_code>
+        </xml>
+        XML
+      )
+    ]
+
+    assert_equal r['return_code'].nil?, false
+    assert_equal r['prepay_id'].nil?, true
+  end
+
   def test_success_method_with_false
-    r = WxPay::Result.new(
+    r = WxPay::Result[
       Hash.from_xml(
         <<-XML
         <xml>
         </xml>
         XML
-      ))
+      )
+    ]
 
     assert_equal r.success?, false
   end


### PR DESCRIPTION
```ruby
# Fix this
hash = {say: 'hello'}
result = WxPay::Result.new hash
result['byebye'] #  => {say: 'hello'} 
```