### PR TITLE
No logic change, fix warning and upgrade to rake 11

### DIFF
--- a/lib/wx_pay.rb
+++ b/lib/wx_pay.rb
@@ -7,7 +7,8 @@ module WxPay
   @extra_rest_client_options = {}
 
   class<< self
-    attr_accessor :appid, :mch_id, :key, :apiclient_cert, :apiclient_key, :extra_rest_client_options
+    attr_accessor :appid, :mch_id, :key, :extra_rest_client_options
+    attr_reader :apiclient_cert, :apiclient_key
 
     def set_apiclient_by_pkcs12(str, pass)
       pkcs12 = OpenSSL::PKCS12.new(str, pass)

--- a/lib/wx_pay/sign.rb
+++ b/lib/wx_pay/sign.rb
@@ -5,8 +5,8 @@ module WxPay
     def self.generate(params)
       key = params.delete(:key)
 
-      query = params.sort.map do |key, value|
-        "#{key}=#{value}" if value != "" && !value.nil?
+      query = params.sort.map do |k, v|
+        "#{k}=#{v}" if v.to_s != ''
       end.compact.join('&')
 
       Digest::MD5.hexdigest("#{query}&key=#{key || WxPay.key}").upcase

--- a/wx_pay.gemspec
+++ b/wx_pay.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport", '>= 3.2'
 
   s.add_development_dependency "bundler", '~> 1'
-  s.add_development_dependency "rake", '~> 10'
+  s.add_development_dependency "rake", '~> 11.2'
   s.add_development_dependency "fakeweb", '~> 1'
   s.add_development_dependency "minitest", '~> 5'
 end


### PR DESCRIPTION
Fix below warning and make `rake` works directly (previous have to running test via `bundle exec rake`)

```
/Users/guochunzhong/git/oss/wx_pay/lib/wx_pay/sign.rb:8: warning: shadowing outer local variable - key
/Users/guochunzhong/git/oss/wx_pay/lib/wx_pay.rb:20: warning: method redefined; discarding old apiclient_cert=
/Users/guochunzhong/git/oss/wx_pay/lib/wx_pay.rb:24: warning: method redefined; discarding old apiclient_key=
```