### PR TITLE
Fix generate_js_pay_req error

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,27 @@ r = WxPay::Service::generate_app_pay_req params
 #    }
 ```
 
+#### pay request for JSAPI
+
+```
+# required fields
+params = {
+  prepayid: '1101000000140415649af9fc314aa427', # fetch by call invoke_unifiedorder with `trade_type` is `JSAPI`
+  noncestr: '1101000000140429eb40476f8896f4c9', # must same as given to invoke_unifiedorder
+}
+
+# call generate_js_pay_req
+r = WxPay::Service.generate_js_pay_req params
+# {
+#   "appId": "wx020c5c792c8537de",
+#   "package": "prepay_id=wx20160902211806a11ccee7a20956539837",
+#   "nonceStr": "2vS5AJUD7uyaa5h9",
+#   "timeStamp": "1472822286",
+#   "signType": "MD5",
+#   "paySign": "A52433CB75CA8D58B67B2BB45A79AA01"
+# }
+```
+
 #### Notify Process
 
 A simple example of processing notify.

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -60,18 +60,17 @@ module WxPay
 
     GENERATE_JS_PAY_REQ_REQUIRED_FIELDS = [:prepayid, :noncestr]
     def self.generate_js_pay_req(params, options = {})
+      check_required_options(params, GENERATE_JS_PAY_REQ_REQUIRED_FIELDS)
+
       params = {
         appId: options.delete(:appid) || WxPay.appid,
-        package: "prepay_id=#{params[:prepayid]}",
-        nonceStr: params[:noncestr],
+        package: "prepay_id=#{params.delete(:prepayid)}",
+        nonceStr: params.delete(:noncestr),
         timeStamp: Time.now.to_i.to_s,
         signType: 'MD5'
       }.merge(params)
 
-      check_required_options(params, GENERATE_JS_PAY_REQ_REQUIRED_FIELDS)
-
       params[:paySign] = WxPay::Sign.generate(params)
-
       params
     end
 

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -62,6 +62,7 @@ module WxPay
     def self.generate_js_pay_req(params, options = {})
       params = {
         appId: options.delete(:appid) || WxPay.appid,
+        nonceStr: params.delete(:noncestr),
         timeStamp: Time.now.to_i.to_s,
         signType: 'MD5'
       }.merge(params)

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -58,11 +58,12 @@ module WxPay
       params
     end
 
-    GENERATE_JS_PAY_REQ_REQUIRED_FIELDS = [:appid, :noncestr, :package]
+    GENERATE_JS_PAY_REQ_REQUIRED_FIELDS = [:prepayid, :noncestr]
     def self.generate_js_pay_req(params, options = {})
       params = {
         appId: options.delete(:appid) || WxPay.appid,
-        nonceStr: params.delete(:noncestr),
+        package: "prepay_id=#{params[:prepayid]}",
+        nonceStr: params[:noncestr],
         timeStamp: Time.now.to_i.to_s,
         signType: 'MD5'
       }.merge(params)


### PR DESCRIPTION
否则报：nonceStr不存在。

已经在wechat-starter的develop分支中验证通过
