### PR TITLE
download_bill返回string无法被xml解析导致错误

### DIFF
--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -291,7 +291,11 @@ module WxPay
           }.merge(options)
         )
 
-        WxPay::Result.new(Hash.from_xml(r))
+        begin
+          WxPay::Result.new(Hash.from_xml(r))
+        rescue REXML::ParseException
+          r
+        end
       end
     end
   end

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -16,7 +16,7 @@ module WxPay
 
       check_required_options(params, INVOKE_UNIFIEDORDER_REQUIRED_FIELDS)
 
-      r = invoke_remote("#{GATEWAY_URL}/pay/unifiedorder", make_payload(params), options)
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/pay/unifiedorder", make_payload(params), options)))
 
       yield r if block_given?
 
@@ -34,7 +34,7 @@ module WxPay
 
       check_required_options(params, INVOKE_CLOSEORDER_REQUIRED_FIELDS)
 
-      r = invoke_remote("#{GATEWAY_URL}/pay/closeorder", make_payload(params), options)
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/pay/closeorder", make_payload(params), options)))
 
       yield r if block_given?
 
@@ -92,7 +92,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = invoke_remote("#{GATEWAY_URL}/secapi/pay/refund", make_payload(params), options)
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/secapi/pay/refund", make_payload(params), options)))
 
       yield r if block_given?
 
@@ -109,7 +109,7 @@ module WxPay
 
       check_required_options(params, ORDER_QUERY_REQUIRED_FIELDS)
 
-      r = invoke_remote("#{GATEWAY_URL}/pay/refundquery", make_payload(params), options)
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/pay/refundquery", make_payload(params), options)))
 
       yield r if block_given?
 
@@ -132,7 +132,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/promotion/transfers", make_payload(params), options)
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/promotion/transfers", make_payload(params), options)))
 
       yield r if block_given?
 
@@ -155,7 +155,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = invoke_remote("#{GATEWAY_URL}/secapi/pay/reverse", make_payload(params), options)
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/secapi/pay/reverse", make_payload(params), options)))
 
       yield r if block_given?
 
@@ -178,7 +178,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = invoke_remote("#{GATEWAY_URL}/pay/micropay", make_payload(params), options)
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/pay/micropay", make_payload(params), options)))
 
       yield r if block_given?
 
@@ -195,7 +195,7 @@ module WxPay
 
       check_required_options(params, ORDER_QUERY_REQUIRED_FIELDS)
 
-      r = invoke_remote("#{GATEWAY_URL}/pay/orderquery", make_payload(params), options)
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/pay/orderquery", make_payload(params), options)))
 
       yield r if block_given?
 
@@ -234,7 +234,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/sendgroupredpack", make_payload(params), options)
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/sendgroupredpack", make_payload(params), options)))
 
       yield r if block_given?
 
@@ -256,7 +256,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/sendredpack", make_payload(params), options)
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/sendredpack", make_payload(params), options)))
 
       yield r if block_given?
 
@@ -282,7 +282,7 @@ module WxPay
       def invoke_remote(url, payload, options = {})
         options = WxPay.extra_rest_client_options.merge(options)
 
-        r = RestClient::Request.execute(
+        RestClient::Request.execute(
           {
             method: :post,
             url: url,
@@ -290,12 +290,6 @@ module WxPay
             headers: { content_type: 'application/xml' }
           }.merge(options)
         )
-
-        begin
-          WxPay::Result.new(Hash.from_xml(r))
-        rescue REXML::ParseException
-          r
-        end
       end
     end
   end


### PR DESCRIPTION
下载对账单返回不是xml所以会导致报错
https://pay.weixin.qq.com/wiki/doc/api/native.php?chapter=9_6