### PR TITLE
简单微信 OAuth2 授权集成

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ r = WxPay::Service.invoke_unifiedorder params
 #    }
 ```
 
+"JSAPI" requires openid in params, authenticate_openid can be used to get it, in case there is not wechat auth integration.
+
+```ruby
+code = params[:code]
+r = WxPay::Service.authenticate_openid code
+# => 'OPENID'
+```
+
 If your trade type is "NATIVE", the result would be like this.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -36,12 +36,14 @@ Create `config/initializers/wx_pay.rb` and put following configurations into it.
 WxPay.appid = 'YOUR_APPID'
 WxPay.key = 'YOUR_KEY'
 WxPay.mch_id = 'YOUR_MCH_ID'
-WxPay.appsecret = 'YOUR_SECREDT'
 WxPay.debug_mode = true # default is `true`
 
 # cert, see https://pay.weixin.qq.com/wiki/doc/api/app/app.php?chapter=4_3
 # using PCKS12
 WxPay.set_apiclient_by_pkcs12(File.read(pkcs12_filepath), pass)
+
+# if you want to use `generate_authorize_req` and `authenticate`
+WxPay.appsecret = 'YOUR_SECRET' 
 
 # optional - configurations for RestClient timeout, etc.
 WxPay.extra_rest_client_options = {timeout: 2, open_timeout: 3}
@@ -89,13 +91,9 @@ r = WxPay::Service.invoke_unifiedorder params
 #    }
 ```
 
-"JSAPI" requires openid in params, authenticate_openid can be used to get it, in case there is not wechat auth integration.
-
-```ruby
-code = params[:code]
-r = WxPay::Service.authenticate_openid code
-# => 'OPENID'
-```
+> "JSAPI" requires openid in params,
+in most cases I suggest you using [omniauth](https://github.com/omniauth/omniauth) with [omniauth-wechat-oauth2](https://github.com/skinnyworm/omniauth-wechat-oauth2) to resolve this,
+but `wx_pay` provides `generate_authorize_url` and `authenticate` to help you get Wechat authorization in simple case.
 
 If your trade type is "NATIVE", the result would be like this.
 
@@ -188,7 +186,7 @@ def notify
 end
 ```
 
-### Integretion with QRCode(二维码)
+### Integrate with QRCode(二维码)
 
 Wechat payment integrating with QRCode is a recommended process flow which will bring users comfortable experience. It is recommended to generate QRCode using `rqrcode` and `rqrcode_png`.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Create `config/initializers/wx_pay.rb` and put following configurations into it.
 WxPay.appid = 'YOUR_APPID'
 WxPay.key = 'YOUR_KEY'
 WxPay.mch_id = 'YOUR_MCH_ID'
+WxPay.appsecret = 'YOUR_SECREDT'
 WxPay.debug_mode = true # default is `true`
 
 # cert, see https://pay.weixin.qq.com/wiki/doc/api/app/app.php?chapter=4_3

--- a/lib/wx_pay.rb
+++ b/lib/wx_pay.rb
@@ -8,7 +8,7 @@ module WxPay
   @debug_mode = true
 
   class<< self
-    attr_accessor :appid, :mch_id, :key, :extra_rest_client_options, :debug_mode
+    attr_accessor :appid, :mch_id, :key, :appsecret, :extra_rest_client_options, :debug_mode
     attr_reader :apiclient_cert, :apiclient_key
 
     def set_apiclient_by_pkcs12(str, pass)

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -1,5 +1,6 @@
 require 'rest_client'
 require 'json'
+require 'cgi'
 require 'securerandom'
 require 'active_support/core_ext/hash/conversions'
 
@@ -9,7 +10,7 @@ module WxPay
 
     def self.generate_authorize_url(redirect_uri, state = nil)
       state ||= SecureRandom.hex 16
-      "https://open.weixin.qq.com/connect/oauth2/authorize?appid=#{WxPay.appid}&redirect_uri=#{redirect_uri}&response_type=code&scope=snsapi_base&state=#{state}"
+      "https://open.weixin.qq.com/connect/oauth2/authorize?appid=#{WxPay.appid}&redirect_uri=#{CGI::escape redirect_uri}&response_type=code&scope=snsapi_base&state=#{state}"
     end
 
     def self.authenticate(authorization_code, options = {})

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -5,6 +5,58 @@ module WxPay
   module Service
     GATEWAY_URL = 'https://api.mch.weixin.qq.com'
 
+    # def self.get_oauth_url_code(self, redirectUrl):
+    #     """生成可以获得code的url"""
+    #     urlObj = {}
+    #     urlObj["appid"] = WxPay.appid
+    #     urlObj["redirect_uri"] = redirectUrl
+    #     urlObj["response_type"] = "code"
+    #     urlObj["scope"] = "snsapi_base"
+    #     urlObj["state"] = "STATE#wechat_redirect"
+    #     bizString = self.formatBizQueryParaMap(urlObj, False)
+    #     return "https://open.weixin.qq.com/connect/oauth2/authorize?"+bizString
+
+    # def createOauthUrlForOpenid(self):
+    #     """生成可以获得openid的url"""
+    #     urlObj = {}
+    #     urlObj["appid"] = WxPay.appid
+    #     urlObj["secret"] = WxPay.APPSECRET
+    #     urlObj["code"] = self.code
+    #     urlObj["grant_type"] = "authorization_code"
+    #     bizString = self.formatBizQueryParaMap(urlObj, False)
+    #     return "https://api.weixin.qq.com/sns/oauth2/access_token?"+bizString
+
+    # def self.invoice_getopenid(params)
+    #   """通过curl向微信提交code，以获取openid"""
+    #   code = "12313132"
+    #   params = {
+    #     appid: WxPay.appid,
+    #     secret: WxPay.appsecret,
+    #     code: code,
+    #     grant_type: "authorization_code"
+    #   }
+    #   r = invoke_remote("https://api.weixin.qq.com/sns/oauth2/access_token?", make_payload(params))
+    #   openid = r['openid']
+    # end
+    def self.authenticate_openid(params)
+      # 当session中没有openid时，则为非登录状态
+      code = params[:code]
+
+      # 如果code参数为空，则为认证第一步，重定向到微信认证
+      if code.nil?
+        redirect_to "https://open.weixin.qq.com/connect/oauth2/authorize?appid=#{WxPay.appid}&redirect_uri=#{request.url}&response_type=code&scope=snsapi_base&state=#{request.url}#wechat_redirect"
+      end
+
+      #如果code参数不为空，则认证到第二步，通过code获取openid，并保存到session中
+      begin
+        url    = "https://api.weixin.qq.com/sns/oauth2/access_token?appid=#{WxPay.appid}&secret=#{WxPay.appsecret}&code=#{code}&grant_type=authorization_code"
+        weixin_openid = JSON.parse(URI.parse(url).read)["openid"]
+      rescue Exception => e
+        puts "Can not get Weixin Open ID"
+      end
+      weixin_openid
+    end
+
     INVOKE_UNIFIEDORDER_REQUIRED_FIELDS = [:body, :out_trade_no, :total_fee, :spbill_create_ip, :notify_url, :trade_type]
     def self.invoke_unifiedorder(params, options = {})
       params = {

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -5,39 +5,6 @@ module WxPay
   module Service
     GATEWAY_URL = 'https://api.mch.weixin.qq.com'
 
-    # def self.get_oauth_url_code(self, redirectUrl):
-    #     """生成可以获得code的url"""
-    #     urlObj = {}
-    #     urlObj["appid"] = WxPay.appid
-    #     urlObj["redirect_uri"] = redirectUrl
-    #     urlObj["response_type"] = "code"
-    #     urlObj["scope"] = "snsapi_base"
-    #     urlObj["state"] = "STATE#wechat_redirect"
-    #     bizString = self.formatBizQueryParaMap(urlObj, False)
-    #     return "https://open.weixin.qq.com/connect/oauth2/authorize?"+bizString
-
-    # def createOauthUrlForOpenid(self):
-    #     """生成可以获得openid的url"""
-    #     urlObj = {}
-    #     urlObj["appid"] = WxPay.appid
-    #     urlObj["secret"] = WxPay.APPSECRET
-    #     urlObj["code"] = self.code
-    #     urlObj["grant_type"] = "authorization_code"
-    #     bizString = self.formatBizQueryParaMap(urlObj, False)
-    #     return "https://api.weixin.qq.com/sns/oauth2/access_token?"+bizString
-
-    # def self.invoice_getopenid(params)
-    #   """通过curl向微信提交code，以获取openid"""
-    #   code = "12313132"
-    #   params = {
-    #     appid: WxPay.appid,
-    #     secret: WxPay.appsecret,
-    #     code: code,
-    #     grant_type: "authorization_code"
-    #   }
-    #   r = invoke_remote("https://api.weixin.qq.com/sns/oauth2/access_token?", make_payload(params))
-    #   openid = r['openid']
-    # end
     def self.authenticate_openid(params)
       # 当session中没有openid时，则为非登录状态
       code = params[:code]

--- a/wx_pay.gemspec
+++ b/wx_pay.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_runtime_dependency "rest-client", '>= 1.7'
+  s.add_runtime_dependency "rest-client", '>= 1.6'
   s.add_runtime_dependency "activesupport", '>= 3.2'
 
   s.add_development_dependency "bundler", '~> 1'

--- a/wx_pay.gemspec
+++ b/wx_pay.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_runtime_dependency "rest-client", '>= 1.6'
+  s.add_runtime_dependency "rest-client", '>= 1.7'
   s.add_runtime_dependency "activesupport", '>= 3.2'
 
   s.add_development_dependency "bundler", '~> 1'


### PR DESCRIPTION
重构 #19 

提供了两个函数方便在项目不集成 omniauth 或者类似的专业授权库的时候获取微信的授权信息

- `generate_authorize_url(redirect_uri, state)` 返回获取 `authorization_code` 的 url，跳转逻辑需要使用者自行实现，`redirect_uri` 是登记在微信后台的URI，state默认不需要提供（这个字段本意是为了防止重放攻击的随机字符串）
- `authenticate(authorization_code)` 获取授权，返回值为反序列化后的微信的授权成功的结构体