### PR TITLE
raw should store response body

### DIFF
--- a/lib/wx_pay/result.rb
+++ b/lib/wx_pay/result.rb
@@ -5,8 +5,9 @@ module WxPay
     def initialize(result)
       super nil # Or it will call `super result`
 
-      self[:raw] = result
       result_hash = Hash.from_xml(result)
+      self[:raw] = result_hash
+      self[:raw_xml] = result
       if result_hash['xml'].class == Hash
         result_hash['xml'].each_pair do |k, v|
           self[k] = v

--- a/lib/wx_pay/result.rb
+++ b/lib/wx_pay/result.rb
@@ -6,9 +6,9 @@ module WxPay
       super nil # Or it will call `super result`
 
       self[:raw] = result
-      
-      if result['xml'].class == Hash
-        result['xml'].each_pair do |k, v|
+      result_hash = Hash.from_xml(result)
+      if result_hash['xml'].class == Hash
+        result_hash['xml'].each_pair do |k, v|
           self[k] = v
         end
       end

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -36,7 +36,7 @@ module WxPay
 
       check_required_options(params, INVOKE_UNIFIEDORDER_REQUIRED_FIELDS)
 
-      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/pay/unifiedorder", make_payload(params), options)))
+      r = WxPay::Result.new(invoke_remote("#{GATEWAY_URL}/pay/unifiedorder", make_payload(params), options).body)
 
       yield r if block_given?
 
@@ -54,7 +54,7 @@ module WxPay
 
       check_required_options(params, INVOKE_CLOSEORDER_REQUIRED_FIELDS)
 
-      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/pay/closeorder", make_payload(params), options)))
+      r = WxPay::Result.new(invoke_remote("#{GATEWAY_URL}/pay/closeorder", make_payload(params), options).body)
 
       yield r if block_given?
 
@@ -112,7 +112,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/secapi/pay/refund", make_payload(params), options)))
+      r = WxPay::Result.new(invoke_remote("#{GATEWAY_URL}/secapi/pay/refund", make_payload(params), options).body)
 
       yield r if block_given?
 
@@ -129,7 +129,7 @@ module WxPay
 
       check_required_options(params, ORDER_QUERY_REQUIRED_FIELDS)
 
-      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/pay/refundquery", make_payload(params), options)))
+      r = WxPay::Result.new(invoke_remote("#{GATEWAY_URL}/pay/refundquery", make_payload(params), options).body)
 
       yield r if block_given?
 
@@ -152,7 +152,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/promotion/transfers", make_payload(params), options)))
+      r = WxPay::Result.new(invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/promotion/transfers", make_payload(params), options).body)
 
       yield r if block_given?
 
@@ -175,7 +175,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/gettransferinfo", make_payload(params), options)))
+      r = WxPay::Result.new(invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/gettransferinfo", make_payload(params), options).body)
 
       yield r if block_given?
 
@@ -198,7 +198,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/secapi/pay/reverse", make_payload(params), options)))
+      r = WxPay::Result.new(invoke_remote("#{GATEWAY_URL}/secapi/pay/reverse", make_payload(params), options).body)
 
       yield r if block_given?
 
@@ -221,7 +221,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/pay/micropay", make_payload(params), options)))
+      r = WxPay::Result.new(invoke_remote("#{GATEWAY_URL}/pay/micropay", make_payload(params), options).body)
 
       yield r if block_given?
 
@@ -237,7 +237,7 @@ module WxPay
       }.merge(params)
 
 
-      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/pay/orderquery", make_payload(params), options)))
+      r = WxPay::Result.new(invoke_remote("#{GATEWAY_URL}/pay/orderquery", make_payload(params), options).body)
       check_required_options(params, ORDER_QUERY_REQUIRED_FIELDS)
 
       yield r if block_given?
@@ -277,7 +277,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/sendgroupredpack", make_payload(params), options)))
+      r = WxPay::Result.new(invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/sendgroupredpack", make_payload(params), options).body)
 
       yield r if block_given?
 
@@ -299,7 +299,7 @@ module WxPay
         verify_ssl: OpenSSL::SSL::VERIFY_NONE
       }.merge(options)
 
-      r = WxPay::Result.new(Hash.from_xml(invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/sendredpack", make_payload(params), options)))
+      r = WxPay::Result.new(invoke_remote("#{GATEWAY_URL}/mmpaymkttransfers/sendredpack", make_payload(params), options).body)
 
       yield r if block_given?
 


### PR DESCRIPTION
raw 存储最原始的 response body 是最好的，这样就可以读取到最原始的数据，而不是序列化之后的