### PR TITLE
add authenticate_from_weapp

### DIFF
--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -25,6 +25,18 @@ module WxPay
       ), quirks_mode: true)
     end
 
+    def self.authenticate_from_weapp(js_code, options = {})
+      options = WxPay.extra_rest_client_options.merge(options)
+      url = "https://api.weixin.qq.com/sns/jscode2session?appid=#{WxPay.appid}&secret=#{WxPay.appsecret}&js_code=#{js_code}&grant_type=authorization_code"
+
+      ::JSON.parse(RestClient::Request.execute(
+        {
+          method: :get,
+          url: url
+        }.merge(options)
+      ), quirks_mode: true)
+    end
+    
     INVOKE_UNIFIEDORDER_REQUIRED_FIELDS = [:body, :out_trade_no, :total_fee, :spbill_create_ip, :notify_url, :trade_type]
     def self.invoke_unifiedorder(params, options = {})
       params = {


### PR DESCRIPTION
用于微信小程序的登录。
相关资料：https://mp.weixin.qq.com/debug/wxadoc/dev/api/api-login.html#wxloginobject。