### PR TITLE
fix signature validation

### DIFF
--- a/lib/wx_pay.rb
+++ b/lib/wx_pay.rb
@@ -9,7 +9,8 @@ module WxPay
   @sandbox_mode = false
 
   class<< self
-    attr_accessor :appid, :mch_id, :key, :appsecret, :extra_rest_client_options, :debug_mode, :sandbox_mode
+    attr_accessor :appid, :mch_id, :key, :appsecret, :extra_rest_client_options, :debug_mode
+    attr_accessor :sandbox_mode, :sandbox_key, :sandbox_mch_id
     attr_reader :apiclient_cert, :apiclient_key
 
     def set_apiclient_by_pkcs12(str, pass)

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -361,6 +361,8 @@ module WxPay
               :mch_id => r['mch_id'] || WxPay.mch_id,
               :key => r['sandbox_signkey']
             })
+            WxPay.sandbox_key = r['sandbox_signkey']
+            WxPay.sandbox_mch_id = r['mch_id']
           else
             warn("WxPay Warn: fetch sandbox sign key failed #{r['return_msg']}")
           end

--- a/lib/wx_pay/sign.rb
+++ b/lib/wx_pay/sign.rb
@@ -15,6 +15,9 @@ module WxPay
     def self.verify?(params, options = {})
       params = params.dup
       params = params.merge(options)
+      if WxPay.sandbox_mode?
+        params = params.merge(mch_id => WxPay.sandbox_mch_id, key => WxPay.sandbox_key)
+      end
 
       sign = params.delete('sign') || params.delete(:sign)
 

--- a/lib/wx_pay/sign.rb
+++ b/lib/wx_pay/sign.rb
@@ -16,7 +16,7 @@ module WxPay
       params = params.dup
       params = params.merge(options)
       if WxPay.sandbox_mode?
-        params = params.merge(mch_id => WxPay.sandbox_mch_id, key => WxPay.sandbox_key)
+        params = params.merge({:mch_id => WxPay.sandbox_mch_id, :key => WxPay.sandbox_key})
       end
 
       sign = params.delete('sign') || params.delete(:sign)


### PR DESCRIPTION
From my test, [this PR](https://github.com/jasl/wx_pay/pull/73) would introduce a bug.
We have to use the same sandbox key to verify the sandbox web hook, not the production one.

@xeodou and I appreciate your great work! Thanks, man!