### PR TITLE
mch_id doesn't show up in response

### DIFF
--- a/lib/wx_pay.rb
+++ b/lib/wx_pay.rb
@@ -1,6 +1,7 @@
 require 'wx_pay/result'
 require 'wx_pay/sign'
 require 'wx_pay/service'
+require 'wx_pay/version'
 require 'openssl'
 
 module WxPay

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -362,7 +362,6 @@ module WxPay
               :key => r['sandbox_signkey']
             })
             WxPay.sandbox_key = r['sandbox_signkey']
-            WxPay.sandbox_mch_id = r['mch_id']
           else
             warn("WxPay Warn: fetch sandbox sign key failed #{r['return_msg']}")
           end

--- a/lib/wx_pay/sign.rb
+++ b/lib/wx_pay/sign.rb
@@ -16,7 +16,7 @@ module WxPay
       params = params.dup
       params = params.merge(options)
       if WxPay.sandbox_mode?
-        params = params.merge({:mch_id => WxPay.sandbox_mch_id, :key => WxPay.sandbox_key})
+        params = params.merge(:key => WxPay.sandbox_key)
       end
 
       sign = params.delete('sign') || params.delete(:sign)


### PR DESCRIPTION
response shows like this
```
{:raw=>{"xml"=>{"return_code"=>"SUCCESS", "return_msg"=>"ok", "sandbox_signkey"=>"63dea5047463872cc1b58db6f5e01673"}}, "return_code"=>"SUCCESS", "return_msg"=>"ok", "sandbox_signkey"=>"63dea5047463872cc1b58db6f5e01673"}

```
so there is no mch_id