### PR TITLE
Add support for pay_bank and query_bank

### DIFF
--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -168,7 +168,8 @@ module WxPay
       params = {
         mch_appid: options.delete(:appid) || WxPay.appid,
         mchid: options.delete(:mch_id) || WxPay.mch_id,
-        nonce_str: SecureRandom.uuid.tr('-', '')
+        nonce_str: SecureRandom.uuid.tr('-', ''),
+        key: options.delete(:key) || WxPay.key
       }.merge(params)
 
       check_required_options(params, INVOKE_TRANSFER_REQUIRED_FIELDS)
@@ -191,7 +192,8 @@ module WxPay
       params = {
         appid: options.delete(:appid) || WxPay.appid,
         mch_id: options.delete(:mch_id) || WxPay.mch_id,
-        nonce_str: SecureRandom.uuid.tr('-', '')
+        nonce_str: SecureRandom.uuid.tr('-', ''),
+        key: options.delete(:key) || WxPay.key
       }.merge(params)
 
       check_required_options(params, GETTRANSFERINFO_FIELDS)
@@ -203,6 +205,74 @@ module WxPay
       }.merge(options)
 
       r = WxPay::Result.new(Hash.from_xml(invoke_remote("/mmpaymkttransfers/gettransferinfo", make_payload(params), options)))
+
+      yield r if block_given?
+
+      r
+    end
+
+    # 获取加密银行卡号和收款方用户名的RSA公钥
+    def self.risk_get_public_key(options = {})
+      params = {
+        mch_id: options.delete(:mch_id) || WxPay.mch_id,
+        nonce_str: SecureRandom.uuid.tr('-', ''),
+        key: options.delete(:key) || WxPay.key,
+        sign_type: 'MD5'
+      }
+
+      options = {
+        ssl_client_cert: options.delete(:apiclient_cert) || WxPay.apiclient_cert,
+        ssl_client_key: options.delete(:apiclient_key) || WxPay.apiclient_key,
+        verify_ssl: OpenSSL::SSL::VERIFY_NONE
+      }.merge(options)
+
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("https://fraud.mch.weixin.qq.com/risk/getpublickey", make_payload(params), options)))
+
+      yield r if block_given?
+
+      r
+    end
+
+    PAY_BANK_FIELDS = [:enc_bank_no, :enc_true_name, :bank_code, :amount, :desc]
+    def self.pay_bank(params, options = {})
+      params = {
+        mch_id: options.delete(:mch_id) || WxPay.mch_id,
+        nonce_str: SecureRandom.uuid.tr('-', ''),
+        key: options.delete(:key) || WxPay.key,
+      }.merge(params)
+
+      check_required_options(params, PAY_BANK_FIELDS)
+
+      options = {
+        ssl_client_cert: options.delete(:apiclient_cert) || WxPay.apiclient_cert,
+        ssl_client_key: options.delete(:apiclient_key) || WxPay.apiclient_key,
+        verify_ssl: OpenSSL::SSL::VERIFY_NONE
+      }.merge(options)
+
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("/mmpaysptrans/pay_bank", make_payload(params), options)))
+
+      yield r if block_given?
+
+      r
+    end
+
+    QUERY_BANK_FIELDS = [:partner_trade_no]
+    def self.query_bank(params, options = {})
+      params = {
+        mch_id: options.delete(:mch_id) || WxPay.mch_id,
+        nonce_str: SecureRandom.uuid.tr('-', ''),
+        key: options.delete(:key) || WxPay.key,
+      }.merge(params)
+
+      check_required_options(params, QUERY_BANK_FIELDS)
+
+      options = {
+        ssl_client_cert: options.delete(:apiclient_cert) || WxPay.apiclient_cert,
+        ssl_client_key: options.delete(:apiclient_key) || WxPay.apiclient_key,
+        verify_ssl: OpenSSL::SSL::VERIFY_NONE
+      }.merge(options)
+
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("/mmpaysptrans/query_bank", make_payload(params), options)))
 
       yield r if block_given?
 
@@ -372,11 +442,12 @@ module WxPay
 
       def invoke_remote(url, payload, options = {})
         options = WxPay.extra_rest_client_options.merge(options)
+        url = url.start_with?("http") ? url : "#{get_gateway_url}#{url}"
 
         RestClient::Request.execute(
           {
             method: :post,
-            url: "#{get_gateway_url}#{url}",
+            url: url,
             payload: payload,
             headers: { content_type: 'application/xml' }
           }.merge(options)


### PR DESCRIPTION
#78 

Example:

```ruby
public_key = OpenSSL::PKey::RSA.new(WxPay::Service.risk_get_public_key["pub_key"])
enc_bank_no = Base64.strict_encode64(public_key.public_encrypt('1234567890123456', OpenSSL::PKey::RSA::PKCS1_OAEP_PADDING))
enc_true_name = Base64.strict_encode64(public_key.public_encrypt('李明', OpenSSL::PKey::RSA::PKCS1_OAEP_PADDING))
WxPay::Service.pay_bank({
  partner_trade_no: "WD11223312",
  enc_bank_no: enc_bank_no,
  enc_true_name: enc_true_name,
  bank_code: 1002,
  amount: 10, 
  desc: "测试"
})
```

我在自己的产品中已经测试过了