### PR TITLE
fix xmlify_payload method

### DIFF
--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -454,7 +454,7 @@ module WxPay
 
       def xmlify_payload(params, sign_type = WxPay::Sign::SIGN_TYPE_MD5)
         sign = WxPay::Sign.generate(params, sign_type)
-        "<xml>#{params.except(:key).map { |k, v| "<#{k}>#{v}</#{k}>" }.join}<sign>#{sign}</sign></xml>"
+        "<xml>#{params.except(:key).sort.map { |k, v| "<#{k}>#{v}</#{k}>" }.join}<sign>#{sign}</sign></xml>"
       end
 
       def make_payload(params, sign_type = WxPay::Sign::SIGN_TYPE_MD5)

--- a/test/wx_pay/service_test.rb
+++ b/test/wx_pay/service_test.rb
@@ -48,7 +48,7 @@ class ServiceTest < MiniTest::Test
       mch_id: 'mch_id',
       key: 'key'
     }
-    xml_str = '<xml><body>测试商品</body><out_trade_no>test003</out_trade_no><total_fee>1</total_fee><spbill_create_ip>127.0.0.1</spbill_create_ip><notify_url>http://making.dev/notify</notify_url><trade_type>JSAPI</trade_type><openid>OPENID</openid><app_id>app_id</app_id><mch_id>mch_id</mch_id><sign>172A2D487A37D13FDE32B874BA823DD6</sign></xml>'
+    xml_str = '<xml><app_id>app_id</app_id><body>测试商品</body><mch_id>mch_id</mch_id><notify_url>http://making.dev/notify</notify_url><openid>OPENID</openid><out_trade_no>test003</out_trade_no><spbill_create_ip>127.0.0.1</spbill_create_ip><total_fee>1</total_fee><trade_type>JSAPI</trade_type><sign>172A2D487A37D13FDE32B874BA823DD6</sign></xml>'
     assert_equal xml_str, WxPay::Service.send(:make_payload, params)
   end
 end


### PR DESCRIPTION
提交的xml也需要排序，不排序，在使用发送红包时，报签名错误。