### PR TITLE
pay request for JSAPI noncestr should be rand

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ r = WxPay::Service.generate_app_pay_req params
 # required fields
 params = {
   prepayid: '1101000000140415649af9fc314aa427', # fetch by call invoke_unifiedorder with `trade_type` is `JSAPI`
-  noncestr: '1101000000140429eb40476f8896f4c9', # must same as given to invoke_unifiedorder
+  noncestr: SecureRandom.hex(16), 
 }
 
 # call generate_js_pay_req


### PR DESCRIPTION
I checked JSAPI, the noncestr is not require to be same with invoke_unifiedorder. 
And it's recommended to be random as the official doc said: "微信支付API接口协议中包含字段nonce_str，主要保证签名不可预测"