### PR TITLE
更新沙箱模式的网关 SANDBOX_GATEWAY_URL

### DIFF
--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -7,7 +7,7 @@ require 'active_support/core_ext/hash/conversions'
 module WxPay
   module Service
     GATEWAY_URL = 'https://api.mch.weixin.qq.com'.freeze
-    SANDBOX_GATEWAY_URL = 'https://api.mch.weixin.qq.com/sandboxnew'.freeze
+    SANDBOX_GATEWAY_URL = 'https://api.mch.weixin.qq.com/xdc/apiv2sandbox'.freeze
     FRAUD_GATEWAY_URL = 'https://fraud.mch.weixin.qq.com'.freeze
 
     def self.generate_authorize_url(redirect_uri, state = nil)


### PR DESCRIPTION
微信最近停用了之前的沙箱模式网关，换了一个新的。使用之前网关的话，会导致调用 `WxPay::Service.get_sandbox_signkey()` 的时候返回 404 错误。
参考链接:
https://developers.weixin.qq.com/community/pay/doc/0002c437a1c6f00ba87ef1a1a5ec01?blockType=8 https://pay.weixin.qq.com/wiki/doc/api/native.php?chapter=23_1